### PR TITLE
Add Args and ConfigPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,21 @@ Available Flags:
 
 ```
 
+You may set a default config file path. When set, the file loads automatically if `-c` or
+`-config` is not provided, and the path appears as the default in help output. An explicit
+`-c` or `-config` flag overrides the default.
+
+```sh
+func main() {
+    appCfg := options{}
+    err := config.New(&appCfg).ConfigPath("config.toml").Load()
+    if err != nil {
+        println("err: %v", err.Error())
+        os.Exit(0)
+    }
+}
+```
+
 You may disable flags entirely. Note, general config flags such as the '-gen' flag are not turned off and will still
 be shown on the help screen.
 

--- a/config.go
+++ b/config.go
@@ -32,6 +32,8 @@ type goConfig struct {
 	genConfig   *string
 	configPath  *string
 
+	defaultConfigPath string
+
 	flags *flg.Flags
 }
 
@@ -141,8 +143,8 @@ func (g *goConfig) Load() error {
 			g.genConfig = flag.String("g", "", "generate config file (toml,json,yaml,env)")
 			flag.StringVar(g.genConfig, "gen", "", "")
 		}
-		g.configPath = flag.String("c", "", "path for config file")
-		flag.StringVar(g.configPath, "config", "", "")
+		g.configPath = flag.String("c", g.defaultConfigPath, "path for config file")
+		flag.StringVar(g.configPath, "config", g.defaultConfigPath, "")
 	}
 
 	f.Usage = func() {
@@ -290,6 +292,14 @@ func (g *goConfig) Version(s string) *goConfig {
 // Description for the app, this message is prepended to the help flag
 func (g *goConfig) Description(s string) *goConfig {
 	g.description = s
+	return g
+}
+
+// ConfigPath sets the default config file path used when -c or -config is not
+// provided. The path appears as the default in help output and is loaded
+// automatically. An explicit -c or -config flag overrides this value.
+func (g *goConfig) ConfigPath(path string) *goConfig {
+	g.defaultConfigPath = path
 	return g
 }
 

--- a/config.go
+++ b/config.go
@@ -259,7 +259,24 @@ func LoadFlag(c interface{}) error {
 	if err := f.Parse(); err != nil {
 		return err
 	}
+	defaultCfg.flags = f
 	return f.Unmarshal(c)
+}
+
+// Args returns the non-flag command-line arguments remaining after Load,
+// LoadOrDie, or LoadFlag. Positional args may appear before, after, or between
+// flags. Returns nil if flags have not been parsed yet.
+func Args() []string {
+	return defaultCfg.Args()
+}
+
+// Args returns the non-flag command-line arguments remaining after Load or
+// LoadOrDie on this config instance. Returns nil if flags have not been parsed.
+func (g *goConfig) Args() []string {
+	if g.flags == nil {
+		return nil
+	}
+	return g.flags.Args()
 }
 
 // Version string that describes the app which enables the -v (version) flag.

--- a/config_test.go
+++ b/config_test.go
@@ -264,6 +264,11 @@ func TestLoadFlag(t *testing.T) {
 		Uint:    2,
 		Float32: 12.3,
 	}
+	defer func() {
+		// clean up flag state so later tests can re-register flags
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		defaultCfg = New(nil)
+	}()
 
 	os.Args = []string{"go-config", "-name=flag", "-enable=false", "-float32=55", "-dura=5s", "-time=2012-02-04"}
 	if err := LoadFlag(&c); err != nil {
@@ -279,6 +284,71 @@ func TestLoadFlag(t *testing.T) {
 	}
 	if eq, diff := trial.Equal(c, exp); !eq {
 		t.Error(diff)
+	}
+}
+
+func TestArgs(t *testing.T) {
+	type input struct {
+		args []string
+	}
+	type output struct {
+		Args []string
+		Name string
+	}
+	fn := func(v ...interface{}) (interface{}, error) {
+		in := v[0].(input)
+		defer func() {
+			// clean up flag state so later tests can re-register flags
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+			defaultCfg = New(nil)
+		}()
+
+		c := &testStruct{}
+		os.Args = append([]string{"go-config"}, in.args...)
+		os.Unsetenv("NAME")
+		if err := Load(c); err != nil {
+			return nil, err
+		}
+		return output{Args: Args(), Name: c.Name}, nil
+	}
+	cases := trial.Cases{
+		"no positional args": {
+			Input:    input{args: []string{"-name=foo"}},
+			Expected: output{Args: []string{}, Name: "foo"},
+		},
+		"positional after flags": {
+			Input:    input{args: []string{"-name=foo", "file1", "file2"}},
+			Expected: output{Args: []string{"file1", "file2"}, Name: "foo"},
+		},
+		"positional before flags": {
+			Input:    input{args: []string{"file1", "file2", "-name=foo"}},
+			Expected: output{Args: []string{"file1", "file2"}, Name: "foo"},
+		},
+		"positional before and after flags": {
+			Input:    input{args: []string{"before", "-name=foo", "after"}},
+			Expected: output{Args: []string{"before", "after"}, Name: "foo"},
+		},
+		"interleaved flags and positionals": {
+			Input:    input{args: []string{"a", "-name=foo", "b", "-enable=true", "c"}},
+			Expected: output{Args: []string{"a", "b", "c"}, Name: "foo"},
+		},
+		"only positional": {
+			Input:    input{args: []string{"a", "b"}},
+			Expected: output{Args: []string{"a", "b"}},
+		},
+		"space-separated flag value among positionals": {
+			Input:    input{args: []string{"pos1", "-name", "foo", "pos2"}},
+			Expected: output{Args: []string{"pos1", "pos2"}, Name: "foo"},
+		},
+	}
+	trial.New(fn, cases).SubTest(t)
+}
+
+func TestArgs_beforeLoad(t *testing.T) {
+	defaultCfg = New(nil)
+	got := Args()
+	if got != nil {
+		t.Errorf("Args() got %v want nil", got)
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -352,6 +352,72 @@ func TestArgs_beforeLoad(t *testing.T) {
 	}
 }
 
+func TestGoConfig_ConfigPath(t *testing.T) {
+	type input struct {
+		configPath string
+		flags      []string
+	}
+	fn := func(v ...interface{}) (interface{}, error) {
+		in := v[0].(input)
+		defer func() {
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		}()
+
+		c := testStruct{
+			Dura:    time.Second,
+			Value:   1,
+			Uint:    2,
+			Float32: 12.3,
+		}
+		os.Args = append([]string{"go-config"}, in.flags...)
+		err := New(&c).ConfigPath(in.configPath).Disable(OptEnv | OptEnvFile).Load()
+		return c, err
+	}
+	cases := trial.Cases{
+		"loads default path when -c not provided": {
+			Input: input{configPath: "test/test.toml"},
+			Expected: testStruct{
+				Name:    "toml",
+				Time:    trial.TimeDay("2010-08-10"),
+				Dura:    10 * time.Second,
+				Enable:  true,
+				Value:   10,
+				Uint:    2,
+				Float32: 99.9,
+			},
+		},
+		"-c overrides default path": {
+			Input: input{
+				configPath: "test/test.toml",
+				flags:      []string{"-c=test/test.yaml"},
+			},
+			Expected: testStruct{
+				Name:    "yaml",
+				Time:    trial.TimeDay("2010-08-10"),
+				Dura:    10 * time.Second,
+				Enable:  true,
+				Value:   10,
+				Uint:    2,
+				Float32: 12.3,
+			},
+		},
+		"empty default does not load file": {
+			Input: input{configPath: ""},
+			Expected: testStruct{
+				Dura:    time.Second,
+				Value:   1,
+				Uint:    2,
+				Float32: 12.3,
+			},
+		},
+		"missing default path returns error": {
+			Input:     input{configPath: "missing.toml"},
+			ShouldErr: true,
+		},
+	}
+	trial.New(fn, cases).SubTest(t)
+}
+
 func TestOptions(t *testing.T) {
 	opt := defaultOpts
 	opt &^= OptToml | OptFlag | OptFiles

--- a/internal/encode/flag/flag.go
+++ b/internal/encode/flag/flag.go
@@ -19,7 +19,8 @@ import (
 
 type Flags struct {
 	*flag.FlagSet
-	defaults map[string]string
+	defaults  map[string]string
+	remaining []string
 }
 
 // New creates a custom flagset based on the struct i.
@@ -132,14 +133,78 @@ func New(i interface{}) (*Flags, error) {
 	return flg, nil
 }
 
-// Parse the internal flags and the user defined flags
+// Parse the internal flags and the user defined flags.
+// Positional args may appear before, after, or between flags.
 func (f *Flags) Parse() error {
 	// add other defined flags
 	flag.VisitAll(func(flg *flag.Flag) {
 		f.Var(flg.Value, flg.Name, flg.Usage)
 	})
 
-	return f.FlagSet.Parse(os.Args[1:])
+	flagArgs, posArgs := splitFlagArgs(f.FlagSet, os.Args[1:])
+	if err := f.FlagSet.Parse(flagArgs); err != nil {
+		return err
+	}
+	if posArgs == nil {
+		posArgs = []string{}
+	}
+	f.remaining = posArgs
+	return nil
+}
+
+// Args returns non-flag arguments remaining after Parse.
+// Unlike flag.FlagSet.Args, this includes positionals that appeared before flags.
+func (f *Flags) Args() []string {
+	return f.remaining
+}
+
+// splitFlagArgs separates flag arguments from positional arguments so the
+// standard library FlagSet (which stops at the first non-flag) can still
+// parse flags that appear after positionals.
+func splitFlagArgs(fs *flag.FlagSet, args []string) (flagArgs, posArgs []string) {
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			posArgs = append(posArgs, args[i+1:]...)
+			break
+		}
+		if len(a) < 2 || a[0] != '-' {
+			posArgs = append(posArgs, a)
+			continue
+		}
+
+		name := a[1:]
+		if strings.HasPrefix(a, "--") {
+			name = a[2:]
+		}
+		if eq := strings.IndexByte(name, '='); eq >= 0 {
+			flagArgs = append(flagArgs, a)
+			continue
+		}
+
+		flagArgs = append(flagArgs, a)
+		if isBoolFlag(fs, name) {
+			continue
+		}
+		if i+1 >= len(args) {
+			continue
+		}
+		i++
+		flagArgs = append(flagArgs, args[i])
+	}
+	return flagArgs, posArgs
+}
+
+func isBoolFlag(fs *flag.FlagSet, name string) bool {
+	flg := fs.Lookup(name)
+	if flg == nil {
+		return false
+	}
+	type boolFlag interface {
+		IsBoolFlag() bool
+	}
+	bf, ok := flg.Value.(boolFlag)
+	return ok && bf.IsBoolFlag()
 }
 
 // Unmarshal the given struct from the flagSet

--- a/internal/encode/flag/flag_test.go
+++ b/internal/encode/flag/flag_test.go
@@ -370,6 +370,70 @@ func TestUnmarshal(t *testing.T) {
 	trial.New(fn, cases).SubTest(t)
 }
 
+func TestFlags_Args(t *testing.T) {
+	type input struct {
+		args []string
+	}
+	type output struct {
+		Args   []string `flag:"-"`
+		Name   string
+		Enable bool
+	}
+	fn := func(v ...interface{}) (interface{}, error) {
+		in := v[0].(input)
+		defer func() {
+			// clean up flag state so later tests can re-register flags
+			flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+		}()
+
+		c := &output{}
+		os.Args = append([]string{"go-config"}, in.args...)
+		f, err := New(c)
+		if err != nil {
+			return nil, err
+		}
+		if err := f.Parse(); err != nil {
+			return nil, err
+		}
+		if err := f.Unmarshal(c); err != nil {
+			return nil, err
+		}
+		c.Args = f.Args()
+		return c, nil
+	}
+	cases := trial.Cases{
+		"no positional args": {
+			Input:    input{args: []string{"-name=foo"}},
+			Expected: &output{Args: []string{}, Name: "foo"},
+		},
+		"positional after flags": {
+			Input:    input{args: []string{"-name=foo", "file1", "file2"}},
+			Expected: &output{Args: []string{"file1", "file2"}, Name: "foo"},
+		},
+		"positional before flags": {
+			Input:    input{args: []string{"file1", "file2", "-name=foo"}},
+			Expected: &output{Args: []string{"file1", "file2"}, Name: "foo"},
+		},
+		"positional before and after flags": {
+			Input:    input{args: []string{"before", "-name=foo", "after"}},
+			Expected: &output{Args: []string{"before", "after"}, Name: "foo"},
+		},
+		"interleaved flags and positionals": {
+			Input:    input{args: []string{"a", "-name=foo", "b", "-enable", "c"}},
+			Expected: &output{Args: []string{"a", "b", "c"}, Name: "foo", Enable: true},
+		},
+		"space-separated flag value among positionals": {
+			Input:    input{args: []string{"pos1", "-name", "foo", "pos2"}},
+			Expected: &output{Args: []string{"pos1", "pos2"}, Name: "foo"},
+		},
+		"double-dash ends flag parsing": {
+			Input:    input{args: []string{"-name=foo", "--", "-not-a-flag", "pos"}},
+			Expected: &output{Args: []string{"-not-a-flag", "pos"}, Name: "foo"},
+		},
+	}
+	trial.New(fn, cases).SubTest(t)
+}
+
 type mAlias int
 
 var nums = []string{"zero", "one", "two", "three", "four", "five"}


### PR DESCRIPTION
### Quality check

- [x] Documentation included
- [x] Test coverage

### Summary

Adds `Args()` to return non-flag command-line arguments after `Load`, `LoadOrDie`, or `LoadFlag`, with support for positionals before, after, or between flags.

Adds `ConfigPath(path)` to set a default config file that loads when `-c` is not provided, appears in help output, and is overridden by an explicit `-c` or `-config` flag.

Reworks flg.Flags.Parse to split positional args from flag args (splitFlagArgs) since the
 standard flag package stops parsing at the first non-flag argument.

Includes table-driven tests in `config_test.go` and `internal/encode/flag/flag_test.go`, plus README notes for both features.
